### PR TITLE
query params passed to markdown library

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ Best served with html-loader.
     }
 }
 ```
+
+## Override default markdown primitive options
+
+Simply add query params by javascript or configuration, example:
+
+```javascript
+{
+    module: {
+        loaders: {
+            { test: /\.md$/, loader: "html!markdown?gfm=false" },
+        ]
+    }
+}
+```

--- a/index.js
+++ b/index.js
@@ -3,9 +3,12 @@
  Author peerigon UG @peerigon
  */
 
-var marked = require("marked");
+var marked = require('marked');
+var loaderUtils = require('loader-utils');
+var assign = require("object-assign");
 
-marked.setOptions({
+// default option
+var options = {
     renderer: new marked.Renderer(),
     gfm: true,
     tables: true,
@@ -14,9 +17,12 @@ marked.setOptions({
     sanitize: true,
     smartLists: true,
     smartypants: false
-});
+};
 
 module.exports = function(markdown) {
+    // merge params and default config
+    var config = assign(options, loaderUtils.parseQuery(this.query));
     this.cacheable();
+    marked.setOptions(config);
     return marked(markdown);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "markdown-loader for webpack",
   "main": "index.js",
   "scripts": {
@@ -23,6 +23,8 @@
   },
   "homepage": "https://github.com/peerigon/markdown-loader",
   "dependencies": {
-    "marked": "^0.3.2"
+    "marked": "^0.3.2",
+    "loader-utils": "^0.2.7",
+    "object-assign": "^2.0.0"
   }
 }


### PR DESCRIPTION
hi,

I needed specific options to pass to markdown library 

https://github.com/chjj/marked

So here is a PR to enhance loader with webpack query params feature:

http://webpack.github.io/docs/loaders.html

It uses https://github.com/webpack/loader-utils and assign library but I think it is a good match ;)

https://github.com/sindresorhus/object-assign