### PR TITLE
add indices to duplicated heading ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,21 @@ var marked = require('marked');
 var loaderUtils = require('loader-utils');
 var assign = require("object-assign");
 
+var renderer = new marked.Renderer();
+var headingCounts = {};
+
+renderer.heading = function(text, level) {
+    var encodedText = encodeURIComponent(text);
+    headingCounts[encodedText] = ++headingCounts[encodedText] || 1;
+    if (headingCounts[encodedText] > 1) {
+        encodedText += '-' + headingCounts[encodedText];
+    }
+    return '<h' + level + ' id="' + encodedText + '">' + text + '</h' + level + '>';
+};
+
 // default option
 var options = {
-    renderer: new marked.Renderer(),
+    renderer: renderer,
     gfm: true,
     tables: true,
     breaks: false,


### PR DESCRIPTION
Ids are duplicated now.

```md
# hello

# hello

# hello
```

```html
<h1 id="hello">hello</h1>
<h1 id="hello-2">hello</h1>
<h1 id="hello-3">hello</h1>
```