### PR TITLE
Added support for full set of marked options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,17 +18,13 @@ var options = {
 
 module.exports = function (markdown) {
     // merge params and default config
-    var query = assign({}, options, loaderUtils.parseQuery(this.query));
+    var query = loaderUtils.parseQuery(this.query);
     var configKey = query.config || "markdownLoader";
-
-    if (this.options[configKey]) {
-        // If present, add custom renderer
-        query.renderer = this.options[configKey].renderer;
-    }
+    var options = assign({}, options, query, this.options[configKey]);
 
     this.cacheable();
 
-    marked.setOptions(query);
+    marked.setOptions(options);
 
     return marked(markdown);
 };


### PR DESCRIPTION
Hi guys,

  Great job in the markdown loader. I'm trying to use more options from marked module: highlight attribute which expects a function (similar to the renderer). I was unable to send such a function as a query param.

  This PR aims to extend the functionality already in place for renderer function. With my changes, all regular marked options are accepted inside `markdownLoader` object.

Alan