### PR TITLE
Allowing different parser instance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,13 @@ var options = {
 module.exports = function (markdown) {
     // merge params and default config
     var query = loaderUtils.parseQuery(this.query);
+
+    var parserKey = query.parser || "markdownParser";
+    var parserInstance = this.options[parserKey];
+    if (parserInstance) {
+      marked = parserInstance;
+    }
+
     var configKey = query.config || "markdownLoader";
     var options = assign({}, options, query, this.options[configKey]);
 


### PR DESCRIPTION
[Marked](https://github.com/chjj/marked) project seems to be deprecated with over 200 issues and hundreds of PRs sitting there.

Our team decided to fork marked project and fix some of the important issues that we are facing.

This PR aims to allow `markdown-loader` to use a different instance of the marked project. I know it is not the perfect solution, but at least will allow people to move forward with some of the problems.

In the long run, I would say it is a good idea to switch to another active markdown parsing engine.

In my webpack config i can do that now:

```
var marked = require('grommet-marked');
var renderer = new marked.Renderer();
renderer.code...
...
var webpackConfig = {
  ...
  markdownLoader: {
    renderer: renderer
  },
  markdownParser: marked
}
```
