### PR TITLE
update loader-utils, exchange deprecated method

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const loaderUtils = require("loader-utils");
 
 module.exports = function (markdown) {
     // merge params and default config
-    const options = loaderUtils.parseQuery(this.query);
+    const options = loaderUtils.getOptions(this);
 
     this.cacheable();
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/peerigon/markdown-loader",
   "dependencies": {
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.1.0",
     "marked": "^0.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade deprecated `loader-utils` and use latest API. Fixes _deprecation warnings_. Resolves to https://github.com/webpack/loader-utils/issues/56