### PR TITLE
Update to marked 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "homepage": "https://github.com/peerigon/markdown-loader",
     "dependencies": {
         "loader-utils": "^1.1.0",
-        "marked": "^0.3.9"
+        "marked": "^0.4.0"
     },
     "devDependencies": {
         "ava": "^0.18.0",

--- a/test/assets/markdown.md
+++ b/test/assets/markdown.md
@@ -9,3 +9,7 @@ _italic_ is the new __bold__
 ```javascript
 const i = 100;
 ```
+
+| name | type |
+| --- | --- |
+| key | `string\|number` |

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,7 +41,7 @@ test.cb(t => {
         }
 
         const bundle = require("./output/bundle");
-        t.is(bundle, '<h1 id=\"heading-1\">heading 1</h1>\n<ul>\n<li>buy pineapple</li>\n</ul>\n<h2 id=\"heading-2\">heading 2</h2>\n<p><em>italic</em> is the new <strong>bold</strong></p>\n<pre><code class=\"lang-javascript\"><span class=\"hljs-attribute\">const i</span> = 100;\n</code></pre>\n');
+        t.is(bundle, '<h1 id=\"heading-1\">heading 1</h1>\n<ul>\n<li>buy pineapple</li>\n</ul>\n<h2 id=\"heading-2\">heading 2</h2>\n<p><em>italic</em> is the new <strong>bold</strong></p>\n<pre><code class=\"language-javascript\"><span class=\"hljs-attribute\">const i</span> = 100;</code></pre>\n<table>\n<thead>\n<tr>\n<th>name</th>\n<th>type</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>key</td>\n<td><code>string|number</code></td>\n</tr>\n</tbody></table>\n');
 
         t.end();
     });


### PR DESCRIPTION
Breaking changes in marked:

- Fix escaping pipes in tables
- Fix html output for tables to match GFM spec
- Fix many bugs to reach parity with CommonMark spec
- Fix new Renderer() so it uses default options
- Fix text and paragraph return types
- Fix \<em> less than 3 chars
- Fix \<pre> code blocks so there is no more trailing \n
- Fix default langPrefix to follow CommonMark standard language-

[Source](https://github.com/markedjs/marked/releases/tag/0.4.0)

Resolves #33 