### PR TITLE
bump marked version to 0.6.0 (closes #47)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/peerigon/markdown-loader",
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "marked": "^0.5.0"
+    "marked": "^0.6.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
Bump marked version to `^0.6.0`

Closes #47 