### PR TITLE
Don't return, export

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In order to specify [custom renderers](https://github.com/peerigon/markdown-load
 const marked = require("marked");
 const renderer = new marked.Renderer();
 
-return {
+module.exports = {
     module: {
         rules: [{
                 test: /\.md$/,


### PR DESCRIPTION
Adds exporting inside example in README, returning doesn't work, because it is not a function.