### PR TITLE
Quick fix to enable usage of Marker extensions

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,8 +1,18 @@
 /* eslint-disable @babel/no-invalid-this */
-import { parse } from "marked";
+import {parse, use} from "marked";
+
+const extensions = [];
 
 export function markdownLoader(markdown) {
   const options = this.getOptions();
 
-  return parse(markdown, options);
+  for(let extension of options.extensions) {
+    if( extensions.includes(extension) )
+      break;
+
+    use(extension);
+    extensions.push(extension);
+  }
+
+  return parse(markdown, options.options);
 }


### PR DESCRIPTION
Quick fix to enable the usage of Marker extensions.

An example with `marked-highlight` :

```javascript
// highlight
const { markedHighlight } = require("./../../example/node_modules/marked-highlight");
const hljs = require('./../../example/node_modules/highlight.js');

// inside Webpack rules :

{
		test: /\.md$/,
		use: [
            {
                /*loader: "html-loader",*/
                loader: 'file-loader',
			    options: { name: `[name].html` }
            },
            {
                loader: "markdown-loader",
                options: { // https://marked.js.org/using_advanced#options
                    options: {},
                    extensions: [
                        markedHighlight({
                            langPrefix: 'hljs language-',
                            highlight(code, lang, info) {
                                const language = hljs.getLanguage(lang) ? lang : 'plaintext';
                                return hljs.highlight(code, { language }).value;
                            }
                        })
                    ]
                },
            },
        ],
	}
```